### PR TITLE
Feature/open save file directory controls

### DIFF
--- a/View/UserControls/TextBoxFileBrowserControl.xaml
+++ b/View/UserControls/TextBoxFileBrowserControl.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl x:Class="View.UserControls.TextBoxFileBrowserControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             d:DesignHeight="26" d:DesignWidth="318">
+    <Grid HorizontalAlignment="stretch" VerticalAlignment="Stretch">
+        <TextBox Name="TextBox" Margin="5" VerticalAlignment="Center" HorizontalAlignment="Stretch" IsEnabled="False" />
+        <Button Content="..." HorizontalAlignment="right" Margin="3" VerticalAlignment="Center" Height="18" Width="18" Click="OpenBrowser"/>
+    </Grid>
+</UserControl>

--- a/View/UserControls/TextBoxFileBrowserControl.xaml.cs
+++ b/View/UserControls/TextBoxFileBrowserControl.xaml.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace View.UserControls
+{
+    public partial class TextBoxFileBrowserControl : UserControl
+    {
+        public static readonly DependencyProperty PathProperty = DependencyProperty.Register("Path", typeof(string), typeof(TextBoxFileBrowserControl), new FrameworkPropertyMetadata(null, new PropertyChangedCallback(PathChangedCallBack)));
+
+        public TextBoxFileBrowserControl()
+        {
+            InitializeComponent();
+            Filter = "XML files (*.xml) |*.xml";
+            FileExists = true;
+        }
+        public string Path
+        {
+            get { return Convert.ToString(GetValue(PathProperty)); }
+            set { SetValue(PathProperty, value);}
+        }
+        public bool FileExists { get; set; }
+        public bool IsOpenDialog { get; set; }
+        public string Filter { get; set; }
+        private static void PathChangedCallBack(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            TextBoxFileBrowserControl owner = sender as TextBoxFileBrowserControl;
+            string p = e.NewValue.ToString();
+            owner.Path = p;
+            owner.TextBox.Text = p;
+        }
+
+        private void OpenBrowser(object sender, RoutedEventArgs e)
+        {
+            if (IsOpenDialog)
+            {
+                Microsoft.Win32.OpenFileDialog fileDialog = new Microsoft.Win32.OpenFileDialog();
+                fileDialog.Filter = Filter;
+                fileDialog.Multiselect = false;
+                fileDialog.CheckFileExists = FileExists;
+                fileDialog.Title = "Open";
+                fileDialog.ShowDialog();
+                Path = fileDialog.FileName;
+
+            }
+            else
+            {
+                Microsoft.Win32.SaveFileDialog fileDialog = new Microsoft.Win32.SaveFileDialog();
+                fileDialog.Title = "Save As" ;
+                fileDialog.Filter = Filter;
+                fileDialog.ShowDialog();
+                Path = fileDialog.FileName;
+            }
+        }
+    }
+}

--- a/View/UserControls/TextBoxFolderBrowserControl.xaml
+++ b/View/UserControls/TextBoxFolderBrowserControl.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl x:Class="View.UserControls.TextBoxFolderBrowserControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d" 
+             d:DesignHeight="26" d:DesignWidth="318">
+    <Grid HorizontalAlignment="stretch" VerticalAlignment="Stretch">
+        <TextBox Name="TextBox" Margin="5" VerticalAlignment="Center" HorizontalAlignment="Stretch" IsEnabled="False" />
+        <Button Content="..." HorizontalAlignment="right" Margin="3" VerticalAlignment="Center" Height="18" Width="18" Click="OpenBrowser"/>
+    </Grid>
+</UserControl>

--- a/View/UserControls/TextBoxFolderBrowserControl.xaml.cs
+++ b/View/UserControls/TextBoxFolderBrowserControl.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.WindowsAPICodePack.Dialogs;
+using System.IO;
+
+namespace View.UserControls
+{
+    public partial class TextBoxFolderBrowserControl : UserControl
+    {
+        public static readonly DependencyProperty PathProperty = DependencyProperty.Register("Path", typeof(string), typeof(TextBoxFolderBrowserControl), new FrameworkPropertyMetadata(null, new PropertyChangedCallback(PathChangedCallBack)));
+
+        public TextBoxFolderBrowserControl()
+        {
+            InitializeComponent();
+        }
+        public string Path
+        {
+            get { return Convert.ToString(GetValue(PathProperty)); }
+            set { SetValue(PathProperty, value); }
+        }
+        public string InitialDirectory { get; set; } = Directory.GetCurrentDirectory();
+        private static void PathChangedCallBack(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            TextBoxFolderBrowserControl owner = sender as TextBoxFolderBrowserControl;
+            string p = e.NewValue.ToString();
+            owner.Path = p;
+            owner.TextBox.Text = p;
+        }
+        private void OpenBrowser(object sender, RoutedEventArgs e)
+        {
+            CommonOpenFileDialog dialog = new CommonOpenFileDialog();
+            dialog.InitialDirectory = InitialDirectory;
+            dialog.IsFolderPicker = true;
+            if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                Path = dialog.FileName;
+            }
+        }
+    }
+}

--- a/View/View.csproj
+++ b/View/View.csproj
@@ -18,6 +18,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="WindowsAPICodePack-Shell" Version="1.1.1" />
+	</ItemGroup>
+
+	<ItemGroup>
 	  <ProjectReference Include="..\Base\Base.csproj" />
 	  <ProjectReference Include="..\ViewModel\ViewModel.csproj" />
 	</ItemGroup>


### PR DESCRIPTION
Added file browser and folder browser.

Unlike file browser, Microsoft hasn't added a default implementation of folder browser to wpf yet. There's lots of people grumping about it on their github. Because of that, I added a reference to their windows API pack where I was able to access what I wanted. 

File browser does save or open. Folder just selects a folder. Both are essentially the same design. 