### PR TITLE
Bug/namespaces

### DIFF
--- a/Base/Attributes/ReporterDisplayNameAttribute.cs
+++ b/Base/Attributes/ReporterDisplayNameAttribute.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Base.Attributes
+namespace HEC.MVVMFramework.Base.Attributes
 {
-    [System.AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public class ReporterDisplayNameAttribute: Attribute
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class ReporterDisplayNameAttribute : Attribute
     {
         private readonly string _displayName;
         public string DisplayName { get { return _displayName; } }

--- a/Base/Base.csproj
+++ b/Base/Base.csproj
@@ -7,12 +7,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<PackageId>HenryGeorgist.Framework.Base</PackageId>
+		<PackageId>HEC.MVVMFramework.Base</PackageId>
 		<VersionPrefix>1.0.0</VersionPrefix>
 		<Description>A reference library providing core functionality for MVVM App Building</Description>
 		<Authors>Will Lehman</Authors>
 		<RepositoryUrl>https://github.com/HenryGeorgist/Framework</RepositoryUrl>
 		<DebugType>embedded</DebugType>
+		<RootNamespace>HEC.MVVMFramework.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 	
 </Project>

--- a/Base/Enumerations/ErrorLevel.cs
+++ b/Base/Enumerations/ErrorLevel.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 
-namespace Base.Enumerations
+namespace HEC.MVVMFramework.Base.Enumerations
 {
     [Flags]
-    public enum ErrorLevel: byte
+    public enum ErrorLevel : byte
     {
         Unassigned = 0X00,
         Info = 0x01,
@@ -11,6 +11,6 @@ namespace Base.Enumerations
         Major = 0x04,
         Fatal = 0x20,
         Severe = 0x40,
-        
+
     }
 }

--- a/Base/Events/MessageEventArgs.cs
+++ b/Base/Events/MessageEventArgs.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Base.Interfaces;
+using HEC.MVVMFramework.Base.Interfaces;
 
-namespace Base.Events
+namespace HEC.MVVMFramework.Base.Events
 {
     public delegate void MessageReportedEventHandler(object sender, MessageEventArgs e);
-    public class MessageEventArgs: EventArgs
+    public class MessageEventArgs : EventArgs
     {
         private readonly IMessage _message;
         public IMessage Message

--- a/Base/Events/ProgressReportEventArgs.cs
+++ b/Base/Events/ProgressReportEventArgs.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Base.Events
+namespace HEC.MVVMFramework.Base.Events
 {
     public delegate void ProgressReportedEventHandler(object sender, ProgressReportEventArgs progress);
-    public class ProgressReportEventArgs: EventArgs 
+    public class ProgressReportEventArgs : EventArgs
     {
         private readonly int _progress;
         public int Progress { get { return _progress; } }

--- a/Base/Events/ReporterAddedEventArgs.cs
+++ b/Base/Events/ReporterAddedEventArgs.cs
@@ -1,16 +1,17 @@
-﻿using System;
+﻿using HEC.MVVMFramework.Base.Interfaces;
+using System;
 
-namespace Base.Events
+namespace HEC.MVVMFramework.Base.Events
 {
     public delegate void ReporterAddedEventHandler(object sender, ReporterAddedEventArgs e);
-    public class ReporterAddedEventArgs: EventArgs
+    public class ReporterAddedEventArgs : EventArgs
     {
-        private readonly Base.Interfaces.IReportMessage _reporter;
-        public Base.Interfaces.IReportMessage Reporter
+        private readonly IReportMessage _reporter;
+        public IReportMessage Reporter
         {
             get { return _reporter; }
         }
-        public ReporterAddedEventArgs(Base.Interfaces.IReportMessage reporter)
+        public ReporterAddedEventArgs(IReportMessage reporter)
         {
             _reporter = reporter;
         }

--- a/Base/Events/ReporterRemovedEventArgs.cs
+++ b/Base/Events/ReporterRemovedEventArgs.cs
@@ -1,17 +1,18 @@
-﻿using System;
+﻿using HEC.MVVMFramework.Base.Interfaces;
+using System;
 
 
-namespace Base.Events
+namespace HEC.MVVMFramework.Base.Events
 {
     public delegate void ReporterRemovedEventHandler(object sender, ReporterRemovedEventArgs e);
     public class ReporterRemovedEventArgs : EventArgs
     {
-        private readonly Base.Interfaces.IReportMessage _reporter;
-        public Base.Interfaces.IReportMessage Reporter
+        private readonly IReportMessage _reporter;
+        public IReportMessage Reporter
         {
             get { return _reporter; }
         }
-        public ReporterRemovedEventArgs(Base.Interfaces.IReportMessage reporter)
+        public ReporterRemovedEventArgs(IReportMessage reporter)
         {
             _reporter = reporter;
         }

--- a/Base/Implementations/Message.cs
+++ b/Base/Implementations/Message.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Base.Interfaces;
+﻿using HEC.MVVMFramework.Base.Interfaces;
 
-namespace Base.Implementations
+namespace HEC.MVVMFramework.Base.Implementations
 {
-    public class Message : Interfaces.IMessage
+    public class Message : IMessage
     {
         private readonly string _message;
         string IMessage.Message

--- a/Base/Implementations/PropertyRule.cs
+++ b/Base/Implementations/PropertyRule.cs
@@ -1,15 +1,15 @@
-﻿using Base.Interfaces;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
-namespace Base.Implementations
+namespace HEC.MVVMFramework.Base.Implementations
 {
     public class PropertyRule : IPropertyRule
     {
         private List<IRule> _rules = new List<IRule>();
         private List<string> _errors;
-        private Base.Enumerations.ErrorLevel _errorLevel;
+        private ErrorLevel _errorLevel;
         public IEnumerable<string> Errors
         {
             get
@@ -25,7 +25,7 @@ namespace Base.Implementations
                 return _rules;
             }
         }
-        public Base.Enumerations.ErrorLevel ErrorLevel
+        public ErrorLevel ErrorLevel
         {
             get
             {
@@ -50,7 +50,7 @@ namespace Base.Implementations
         public void Update()
         {
             _errors = new List<string>();
-            _errorLevel = Base.Enumerations.ErrorLevel.Unassigned;
+            _errorLevel = ErrorLevel.Unassigned;
             try
             {
                 foreach (IRule r in _rules)
@@ -58,7 +58,7 @@ namespace Base.Implementations
                     if (!r.Expression())
                     {
                         _errors.Add(r.Message);
-                        if (_errorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                        if (_errorLevel > ErrorLevel.Unassigned)
                         {
                             _errorLevel = _errorLevel | r.ErrorLevel;
                         }
@@ -73,7 +73,7 @@ namespace Base.Implementations
             catch (Exception e)
             {
                 _errors.Add(e.Message);
-                _errorLevel = Base.Enumerations.ErrorLevel.Fatal;
+                _errorLevel = ErrorLevel.Fatal;
             }
         }
 

--- a/Base/Implementations/Rule.cs
+++ b/Base/Implementations/Rule.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
+using System;
 
-namespace Base.Implementations
+namespace HEC.MVVMFramework.Base.Implementations
 {
-    public class Rule : Base.Interfaces.IRule
+    public class Rule : IRule
     {
         private readonly Func<bool> _expression;
         private readonly string _message;
-        private readonly Base.Enumerations.ErrorLevel _errorLevel;
+        private readonly ErrorLevel _errorLevel;
         public Func<bool> Expression
         {
             get
@@ -23,14 +23,14 @@ namespace Base.Implementations
                 return _message;
             }
         }
-        public Base.Enumerations.ErrorLevel ErrorLevel
+        public ErrorLevel ErrorLevel
         {
             get { return _errorLevel; }
         }
-        public Rule(Func<bool> expr, string msg) : this(expr, msg, Base.Enumerations.ErrorLevel.Info)
+        public Rule(Func<bool> expr, string msg) : this(expr, msg, ErrorLevel.Info)
         {
         }
-        public Rule(Func<bool> expr, string msg, Base.Enumerations.ErrorLevel errorLevel)
+        public Rule(Func<bool> expr, string msg, ErrorLevel errorLevel)
         {
             _expression = expr;
             _message = msg;

--- a/Base/Implementations/Validation.cs
+++ b/Base/Implementations/Validation.cs
@@ -1,27 +1,28 @@
 ﻿using Base.Interfaces;
+using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Text;
 
-namespace Base.Implementations
+namespace HEC.MVVMFramework.Base.Implementations
 {
-    public class Validation: IValidate
+    public class Validation : IValidate
     {
         public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
         private Dictionary<string, IPropertyRule> _RuleMap = new Dictionary<string, IPropertyRule>();
         private List<string> _Errors;
         private INamedAction _ErrorsAction;
-        private Base.Enumerations.ErrorLevel _errorLevel;
+        private ErrorLevel _errorLevel;
         public bool HasErrors
         {
             get
             {
-                return _errorLevel > Base.Enumerations.ErrorLevel.Unassigned;
+                return _errorLevel > ErrorLevel.Unassigned;
             }
         }
-        public Base.Interfaces.INamedAction ErrorsAction
+        public INamedAction ErrorsAction
         {
             get { return _ErrorsAction; }
             set { _ErrorsAction = value; }
@@ -33,7 +34,7 @@ namespace Base.Implementations
                 return _RuleMap;
             }
         }
-        public Base.Enumerations.ErrorLevel ErrorLevel
+        public ErrorLevel ErrorLevel
         {
             get { return _errorLevel; }
         }
@@ -77,7 +78,7 @@ namespace Base.Implementations
             if (propertyName == null) return null;
             if (_RuleMap.ContainsKey(propertyName))
             {
-                if (_RuleMap[propertyName].ErrorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                if (_RuleMap[propertyName].ErrorLevel > ErrorLevel.Unassigned)
                 {
                     return _RuleMap[propertyName].Errors;
                 }
@@ -99,14 +100,14 @@ namespace Base.Implementations
         public void Validate()
         {
             _Errors = new List<string>();
-            Base.Enumerations.ErrorLevel prevErrorState = _errorLevel;
-            _errorLevel = Base.Enumerations.ErrorLevel.Unassigned;
+            ErrorLevel prevErrorState = _errorLevel;
+            _errorLevel = ErrorLevel.Unassigned;
             foreach (string s in _RuleMap.Keys)
             {
                 _RuleMap[s].Update();
-                if (_RuleMap[s].ErrorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                if (_RuleMap[s].ErrorLevel > ErrorLevel.Unassigned)
                 {
-                    if (_errorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                    if (_errorLevel > ErrorLevel.Unassigned)
                     {
                         _errorLevel = _RuleMap[s].ErrorLevel;
                     }
@@ -117,14 +118,14 @@ namespace Base.Implementations
                     _Errors.AddRange(_RuleMap[s].Errors);
                 }
             }
-            if (_errorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+            if (_errorLevel > ErrorLevel.Unassigned)
             {
                 //errors exist
                 if (_errorLevel != prevErrorState)
                 {
-                    Base.Enumerations.ErrorLevel changed = _errorLevel ^ prevErrorState;
+                    ErrorLevel changed = _errorLevel ^ prevErrorState;
                     //NotifyPropertyChanged(nameof(HasErrors));
-                    foreach (Base.Enumerations.ErrorLevel e in Enum.GetValues(typeof(Base.Enumerations.ErrorLevel)))
+                    foreach (ErrorLevel e in Enum.GetValues(typeof(ErrorLevel)))
                     {
                         if ((changed & e) > 0)
                         {
@@ -151,14 +152,14 @@ namespace Base.Implementations
         }
         public void Validate(string propertyName)
         {
-            Base.Enumerations.ErrorLevel prevState = _RuleMap[propertyName].ErrorLevel;
+            ErrorLevel prevState = _RuleMap[propertyName].ErrorLevel;
             _RuleMap[propertyName].Update();
             if (prevState != _RuleMap[propertyName].ErrorLevel)
             {
                 //a change occured.
 
                 ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
-                Base.Enumerations.ErrorLevel currState = _RuleMap[propertyName].ErrorLevel;
+                ErrorLevel currState = _RuleMap[propertyName].ErrorLevel;
 
                 //check if it is the biggest one.
                 bool biggerErrorsExist = false;
@@ -171,8 +172,8 @@ namespace Base.Implementations
                 }
                 if (!biggerErrorsExist)
                 {
-                    if (currState == Base.Enumerations.ErrorLevel.Unassigned) _errorLevel = currState;
-                    if (_errorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                    if (currState == ErrorLevel.Unassigned) _errorLevel = currState;
+                    if (_errorLevel > ErrorLevel.Unassigned)
                     {
                         _errorLevel = _errorLevel | currState;
                     }
@@ -181,7 +182,8 @@ namespace Base.Implementations
                         _errorLevel = currState;
                     }
                 }
-                if ((currState ^ prevState) > 0) {
+                if ((currState ^ prevState) > 0)
+                {
                     //NotifyPropertyChanged(nameof(HasErrors)); 
                 }
             }

--- a/Base/Interfaces/IDirectory.cs
+++ b/Base/Interfaces/IDirectory.cs
@@ -1,6 +1,4 @@
-﻿
-
-namespace Base.Interfaces
+﻿namespace HEC.MVVMFramework.Base.Interfaces
 {
     interface IDirectory
     {

--- a/Base/Interfaces/IErrorMessage.cs
+++ b/Base/Interfaces/IErrorMessage.cs
@@ -1,9 +1,10 @@
-﻿
-namespace Base.Interfaces
+﻿using HEC.MVVMFramework.Base.Enumerations;
+
+namespace HEC.MVVMFramework.Base.Interfaces
 {
-    public interface IErrorMessage: IMessage
+    public interface IErrorMessage : IMessage
     {
-        Enumerations.ErrorLevel ErrorLevel { get; }
+        ErrorLevel ErrorLevel { get; }
 
     }
 }

--- a/Base/Interfaces/IMessage.cs
+++ b/Base/Interfaces/IMessage.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Base.Interfaces
+﻿namespace HEC.MVVMFramework.Base.Interfaces
 {
     public interface IMessage
     {

--- a/Base/Interfaces/INamed.cs
+++ b/Base/Interfaces/INamed.cs
@@ -1,6 +1,4 @@
-﻿
-
-namespace Base.Interfaces
+﻿namespace HEC.MVVMFramework.Base.Interfaces
 {
     public interface INamed
     {

--- a/Base/Interfaces/INamedAction.cs
+++ b/Base/Interfaces/INamedAction.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Base.Interfaces
+namespace HEC.MVVMFramework.Base.Interfaces
 {
     public interface INamedAction : INamed
     {

--- a/Base/Interfaces/IPropertyRule.cs
+++ b/Base/Interfaces/IPropertyRule.cs
@@ -1,14 +1,13 @@
-﻿
-
+﻿using HEC.MVVMFramework.Base.Enumerations;
 using System.Collections.Generic;
 
-namespace Base.Interfaces
+namespace HEC.MVVMFramework.Base.Interfaces
 {
     public interface IPropertyRule
     {
         List<IRule> Rules { get; }
         IEnumerable<string> Errors { get; }
-        Enumerations.ErrorLevel ErrorLevel { get; }
+        ErrorLevel ErrorLevel { get; }
         void AddRule(IRule rule);
         void Update();
     }

--- a/Base/Interfaces/IRecieveInstanceMessages.cs
+++ b/Base/Interfaces/IRecieveInstanceMessages.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Base.Interfaces
+﻿namespace HEC.MVVMFramework.Base.Interfaces
 {
-    interface IRecieveInstanceMessages:IRecieveMessages
+    interface IRecieveInstanceMessages : IRecieveMessages
     {
         int InstanceHash { get; }
     }

--- a/Base/Interfaces/IRecieveMessages.cs
+++ b/Base/Interfaces/IRecieveMessages.cs
@@ -1,16 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Events;
+using System;
 
-namespace Base.Interfaces
+namespace HEC.MVVMFramework.Base.Interfaces
 {
     public interface IRecieveMessages
     {
-        Enumerations.ErrorLevel FilterLevel { get; }
+        ErrorLevel FilterLevel { get; }
         Type SenderTypeFilter { get; }
         Type MessageTypeFilter { get; }
-        void RecieveMessage(object sender, Events.MessageEventArgs e);
+        void RecieveMessage(object sender, MessageEventArgs e);
     }
 }

--- a/Base/Interfaces/IReportMessage.cs
+++ b/Base/Interfaces/IReportMessage.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using HEC.MVVMFramework.Base.Events;
 
-namespace Base.Interfaces
+namespace HEC.MVVMFramework.Base.Interfaces
 {
     public interface IReportMessage
     {
-        event Events.MessageReportedEventHandler MessageReport;
-        void ReportMessage(object sender, Events.MessageEventArgs e);
+        event MessageReportedEventHandler MessageReport;
+        void ReportMessage(object sender, MessageEventArgs e);
     }
 }

--- a/Base/Interfaces/IReportProgress.cs
+++ b/Base/Interfaces/IReportProgress.cs
@@ -1,7 +1,6 @@
-﻿
-namespace Base.Interfaces
+﻿namespace HEC.MVVMFramework.Base.Interfaces
 {
-    public interface IProgressReport: IReportMessage
+    public interface IProgressReport : IReportMessage
     {
         event Events.ProgressReportedEventHandler ProgressReport;
         void ReportProgress(object sender, Events.ProgressReportEventArgs e);

--- a/Base/Interfaces/IRule.cs
+++ b/Base/Interfaces/IRule.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using System;
 
-namespace Base.Interfaces
+namespace HEC.MVVMFramework.Base.Interfaces
 {
     public interface IRule
     {
-        Base.Enumerations.ErrorLevel ErrorLevel { get; }
+        ErrorLevel ErrorLevel { get; }
         Func<bool> Expression { get; }
         string Message { get; }
     }

--- a/Base/Interfaces/ITrackChanges.cs
+++ b/Base/Interfaces/ITrackChanges.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Base.Interfaces
+﻿namespace HEC.MVVMFramework.Base.Interfaces
 {
     public interface ITrackChanges
     {

--- a/Base/Interfaces/IUndoRedo.cs
+++ b/Base/Interfaces/IUndoRedo.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using HEC.MVVMFramework.Base.Interfaces;
+
 namespace Base.Interfaces
 {
     public interface IUndoRedo: ITrackChanges

--- a/Base/Interfaces/IValidate.cs
+++ b/Base/Interfaces/IValidate.cs
@@ -1,12 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
+using System.Collections.Generic;
 
 namespace Base.Interfaces
 {
     public interface IValidate : System.ComponentModel.INotifyDataErrorInfo
     {
         Dictionary<string,IPropertyRule> RuleMap { get; }
-        Base.Enumerations.ErrorLevel ErrorLevel { get; }
-        Base.Interfaces.INamedAction ErrorsAction { get; }
+        ErrorLevel ErrorLevel { get; }
+        INamedAction ErrorsAction { get; }
         void AddMultiPropertyRule(List<string> properties, IRule rule);
         void AddSinglePropertyRule(string property, IRule rule);
         /// <summary>

--- a/Model/Messaging/DebuggingErrorMessage.cs
+++ b/Model/Messaging/DebuggingErrorMessage.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,7 +10,7 @@ namespace Model.Messaging
         private readonly string _callingMethod;
         private readonly string _callingClass;
         private readonly int _callingLine;
-        public DebuggingErrorMessage(string message, Base.Enumerations.ErrorLevel errorLevel, [System.Runtime.CompilerServices.CallerMemberNameAttribute] string memberName = "", [System.Runtime.CompilerServices.CallerFilePathAttribute] string filePath = "", [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNo = 0) : base(message,errorLevel)
+        public DebuggingErrorMessage(string message, ErrorLevel errorLevel, [System.Runtime.CompilerServices.CallerMemberNameAttribute] string memberName = "", [System.Runtime.CompilerServices.CallerFilePathAttribute] string filePath = "", [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNo = 0) : base(message,errorLevel)
         {
             _callingMethod = memberName;
             _callingClass = filePath.Split(new char[] { '\\' }).Last();

--- a/Model/Messaging/ErrorMessage.cs
+++ b/Model/Messaging/ErrorMessage.cs
@@ -1,9 +1,10 @@
 ﻿using System;
-using Base.Enumerations;
+using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
 
 namespace Model.Messaging
 {
-    public class ErrorMessage : Base.Interfaces.IErrorMessage
+    public class ErrorMessage : IErrorMessage
     {
         private readonly ErrorLevel _errorLevel;
         private readonly string _message;

--- a/Model/Messaging/TimeStampedErrorMessage.cs
+++ b/Model/Messaging/TimeStampedErrorMessage.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using System;
 
 namespace Model.Messaging
 {
     public class TimeStampedErrorMessage: ErrorMessage
     {
         protected readonly DateTime _DateTime;
-        public TimeStampedErrorMessage(string message, Base.Enumerations.ErrorLevel errorLevel): base(message,errorLevel)
+        public TimeStampedErrorMessage(string message, ErrorLevel errorLevel): base(message,errorLevel)
         {
             _DateTime = DateTime.Now;
         }

--- a/Model/Model.csproj
+++ b/Model/Model.csproj
@@ -7,20 +7,17 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<PackageId>HenryGeorgist.Framework.Model</PackageId>
+		<PackageId>HEC.MVVMFramework.Model</PackageId>
 		<VersionPrefix>1.0.0</VersionPrefix>
 		<Description>A library providing functionality for MVVM Models</Description>
 		<Authors>Will Lehman</Authors>
 		<RepositoryUrl>https://github.com/HenryGeorgist/Framework</RepositoryUrl>
 		<DebugType>embedded</DebugType>
+		<RootNamespace>HEC.MVVMFramework.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\Base\Base.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Validation\" />
 	</ItemGroup>
 
 </Project>

--- a/View/Implementations/TextFileMessageSubscriber.cs
+++ b/View/Implementations/TextFileMessageSubscriber.cs
@@ -3,15 +3,16 @@ using System.Collections;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Base.Enumerations;
-using Base.Events;
 using System.IO;
 using System.Threading;
-
+using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Events;
+using HEC.MVVMFramework.Base.Interfaces;
+using HEC.MVVMFramework.Base.Implementations;
 
 namespace View.Implementations
 {
-    public sealed class TextFileMessageSubscriber : Base.Interfaces.IRecieveMessages, IDisposable
+    public sealed class TextFileMessageSubscriber : IRecieveMessages, IDisposable
     {
         private ErrorLevel _filterLevel = ErrorLevel.Unassigned;
         private Type _messageTypeFilter = null;
@@ -25,7 +26,7 @@ namespace View.Implementations
         System.IO.StreamWriter sw;
         //private System.Collections.Generic.List<System.ComponentModel.BackgroundWorker> _bwList;
         private System.ComponentModel.BackgroundWorker _bw;
-        private System.Collections.Concurrent.ConcurrentQueue<Base.Interfaces.IMessage> _messages;
+        private System.Collections.Concurrent.ConcurrentQueue<IMessage> _messages;
         public static TextFileMessageSubscriber Instance = new TextFileMessageSubscriber();
         public ErrorLevel FilterLevel
         {
@@ -79,9 +80,9 @@ namespace View.Implementations
         }
         private TextFileMessageSubscriber()
         {
-            _messages = new System.Collections.Concurrent.ConcurrentQueue<Base.Interfaces.IMessage>();
+            _messages = new System.Collections.Concurrent.ConcurrentQueue<IMessage>();
             //register
-            Base.Implementations.MessageHub.Subscribe(this);
+            MessageHub.Subscribe(this);
             if (!System.IO.File.Exists(_filePath)) { System.IO.File.Create(_filePath); }
             sw = new StreamWriter(new FileStream(_filePath, FileMode.Create, FileAccess.Write));
             sw.AutoFlush = true;
@@ -110,7 +111,7 @@ namespace View.Implementations
         private void DeQueue()
         {
             System.Text.StringBuilder s = new StringBuilder();
-            Base.Interfaces.IMessage imess;
+            IMessage imess;
             while (_messages.TryDequeue(out imess))
             {
                 s.AppendLine(imess.ToString());

--- a/View/NamedActionConverters/ContextMenuConverter.cs
+++ b/View/NamedActionConverters/ContextMenuConverter.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Windows.Data;
 
-namespace View.NamedActionConverters
+namespace HEC.MVVMFramework.View.NamedActionConverters
 {
     public class ContextMenuConverter : IValueConverter
     {
@@ -42,18 +41,18 @@ namespace View.NamedActionConverters
                     headerBinding.Source = Action;
                     headerBinding.Mode = BindingMode.OneWay;
                     headerBinding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
-                    BindingOperations.SetBinding(mi, System.Windows.Controls.MenuItem.HeaderProperty, headerBinding);
+                    BindingOperations.SetBinding(mi, System.Windows.Controls.HeaderedItemsControl.HeaderProperty, headerBinding);
                     Binding enabledBinding = new Binding("Enabled");
                     enabledBinding.Source = Action;
                     enabledBinding.Mode = BindingMode.OneWay;
                     enabledBinding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
-                    BindingOperations.SetBinding(mi, System.Windows.Controls.MenuItem.IsEnabledProperty, enabledBinding);
+                    BindingOperations.SetBinding(mi, System.Windows.UIElement.IsEnabledProperty, enabledBinding);
                     Binding visibilityBinding = new Binding("Visible");
                     visibilityBinding.Source = Action;
                     visibilityBinding.Mode = BindingMode.OneWay;
                     visibilityBinding.Converter = new System.Windows.Controls.BooleanToVisibilityConverter();
                     visibilityBinding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
-                    BindingOperations.SetBinding(mi, System.Windows.Controls.MenuItem.VisibilityProperty, visibilityBinding);
+                    BindingOperations.SetBinding(mi, System.Windows.UIElement.VisibilityProperty, visibilityBinding);
                     mi.Click += (ob, ev) => Action.Action(ob, ev);
                     c.Items.Add(mi);
 

--- a/View/NamedActionConverters/ImageNamedActionButton.xaml
+++ b/View/NamedActionConverters/ImageNamedActionButton.xaml
@@ -1,9 +1,9 @@
-﻿<UserControl x:Class="View.NamedActionConverters.ImageNamedActionButton"
+﻿<UserControl x:Class="HEC.MVVMFramework.View.NamedActionConverters.ImageNamedActionButton"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:View.NamedActionConverters"
+             xmlns:local="clr-namespace:HEC.MVVMFramework.View.NamedActionConverters"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>

--- a/View/NamedActionConverters/ImageNamedActionButton.xaml.cs
+++ b/View/NamedActionConverters/ImageNamedActionButton.xaml.cs
@@ -1,26 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using HEC.MVVMFramework.Base.Interfaces;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
-namespace View.NamedActionConverters
+namespace HEC.MVVMFramework.View.NamedActionConverters
 {
     /// <summary>
     /// Interaction logic for ImageNamedActionButton.xaml
     /// </summary>
     public partial class ImageNamedActionButton : UserControl
     {
-        public static DependencyProperty ButtonNamedActionProperty = DependencyProperty.Register(nameof(NamedAction), typeof(Base.Interfaces.INamedAction), typeof(ImageNamedActionButton), new FrameworkPropertyMetadata(null,ButtonNamedActionPropertyCallback, ButtonNamedActionPropertyCallbackCoerce), new ValidateValueCallback(IsValidNamedAction));
+        public static DependencyProperty ButtonNamedActionProperty = DependencyProperty.Register(nameof(NamedAction), typeof(INamedAction), typeof(ImageNamedActionButton), new FrameworkPropertyMetadata(null,ButtonNamedActionPropertyCallback, ButtonNamedActionPropertyCallbackCoerce), new ValidateValueCallback(IsValidNamedAction));
         public static DependencyProperty ImageProperty = DependencyProperty.Register(nameof(Image), typeof(object), typeof(ImageNamedActionButton), new PropertyMetadata(ImageChangedCallback));
         public static DependencyProperty ButtonToolTipProperty = DependencyProperty.Register(nameof(ButtonToolTip), typeof(object), typeof(ImageNamedActionButton), new PropertyMetadata(ToolTipChangedCallback));
         public static DependencyProperty ButtonStyleProperty = DependencyProperty.Register(nameof(ButtonStyle), typeof(System.Windows.Style), typeof(ImageNamedActionButton), new PropertyMetadata(StyleChangedCallback));
@@ -41,11 +31,11 @@ namespace View.NamedActionConverters
             set { SetValue(ButtonToolTipProperty, value); }
         }
         private bool _useImage = true;
-        public Base.Interfaces.INamedAction NamedAction
+        public INamedAction NamedAction
         {
             get
             {
-                return (Base.Interfaces.INamedAction)GetValue(ButtonNamedActionProperty);
+                return (INamedAction)GetValue(ButtonNamedActionProperty);
             }
             set
             {
@@ -80,7 +70,7 @@ namespace View.NamedActionConverters
             {
                 btn.Click -= nab._ActionHandler;
             }
-            Base.Interfaces.INamedAction na = (Base.Interfaces.INamedAction)e.NewValue;
+            INamedAction na = (INamedAction)e.NewValue;
             if (na == null)
             {
                 btn.Visibility = Visibility.Collapsed;
@@ -99,7 +89,7 @@ namespace View.NamedActionConverters
             }
             if (!nab._useImage)
             {
-                Binding headerBinding = new Binding(nameof(Base.Interfaces.INamedAction.Name));
+                Binding headerBinding = new Binding(nameof(INamedAction.Name));
                 headerBinding.Source = na;
                 headerBinding.Mode = BindingMode.OneWay;
                 headerBinding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;

--- a/View/NamedActionConverters/NamedActionButton.xaml
+++ b/View/NamedActionConverters/NamedActionButton.xaml
@@ -1,9 +1,9 @@
-﻿<UserControl x:Class="View.NamedActionConverters.NamedActionButton"
+﻿<UserControl x:Class="HEC.MVVMFramework.View.NamedActionConverters.NamedActionButton"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:View.NamedActionConverters"
+             xmlns:local="clr-namespace:HEC.MVVMFramework.View.NamedActionConverters"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>

--- a/View/NamedActionConverters/NamedActionButton.xaml.cs
+++ b/View/NamedActionConverters/NamedActionButton.xaml.cs
@@ -2,24 +2,25 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using Base.Events;
+using HEC.MVVMFramework.Base.Events;
+using HEC.MVVMFramework.Base.Interfaces;
 
-namespace View.NamedActionConverters
+namespace HEC.MVVMFramework.View.NamedActionConverters
 {
     /// <summary>
     /// Interaction logic for NamedActionButton.xaml
     /// </summary>
     public partial class NamedActionButton : UserControl
     {
-        public static DependencyProperty ButtonNamedActionProperty = DependencyProperty.Register(nameof(NamedAction), typeof(Base.Interfaces.INamedAction), typeof(NamedActionButton), new FrameworkPropertyMetadata(ButtonNamedActionPropertyCallback));
+        public static DependencyProperty ButtonNamedActionProperty = DependencyProperty.Register(nameof(NamedAction), typeof(INamedAction), typeof(NamedActionButton), new FrameworkPropertyMetadata(ButtonNamedActionPropertyCallback));
         private RoutedEventHandler _ActionHandler;
         public event MessageReportedEventHandler MessageReport;
 
-        public Base.Interfaces.INamedAction NamedAction
+        public INamedAction NamedAction
         {
             get
             {
-                return (Base.Interfaces.INamedAction)GetValue(ButtonNamedActionProperty);
+                return (INamedAction)GetValue(ButtonNamedActionProperty);
             }
             set
             {
@@ -39,7 +40,7 @@ namespace View.NamedActionConverters
             {
                 btn.Click -= nab._ActionHandler;
             }
-            Base.Interfaces.INamedAction na = (Base.Interfaces.INamedAction)e.NewValue;
+            INamedAction na = (INamedAction)e.NewValue;
             Binding headerBinding = new Binding("Name");
             headerBinding.Source = na;
             headerBinding.Mode = BindingMode.OneWay;

--- a/View/UserControls/ErrorReport.xaml
+++ b/View/UserControls/ErrorReport.xaml
@@ -1,9 +1,9 @@
-﻿<UserControl x:Class="View.UserControls.ErrorReport"
+﻿<UserControl x:Class="HEC.MVVMFramework.View.UserControls.ErrorReport"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:View.UserControls"
+             xmlns:local="clr-namespace:HEC.MVVMFramework.View.UserControls"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>

--- a/View/UserControls/ErrorReport.xaml.cs
+++ b/View/UserControls/ErrorReport.xaml.cs
@@ -1,19 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
-namespace View.UserControls
+namespace HEC.MVVMFramework.View.UserControls
 {
     /// <summary>
     /// Interaction logic for ErrorReport.xaml

--- a/View/UserControls/MessageView.xaml
+++ b/View/UserControls/MessageView.xaml
@@ -1,9 +1,9 @@
-﻿<UserControl x:Class="View.UserControls.MessageView"
+﻿<UserControl x:Class="HEC.MVVMFramework.View.UserControls.MessageView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:View.UserControls"
+             xmlns:local="clr-namespace:HEC.MVVMFramework.View.UserControls"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>

--- a/View/UserControls/MessageView.xaml.cs
+++ b/View/UserControls/MessageView.xaml.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Media;
 
-namespace View.UserControls
+namespace HEC.MVVMFramework.View.UserControls
 {
     public delegate void UpdateDocumentCallBack(Paragraph p);
     /// <summary>
@@ -13,12 +14,12 @@ namespace View.UserControls
     /// </summary>
     public partial class MessageView : UserControl
     {
-        public static readonly DependencyProperty MessageProperty = DependencyProperty.Register(nameof(Message), typeof(Base.Interfaces.IMessage), typeof(MessageView), new PropertyMetadata(MessagesChangedCallback));
+        public static readonly DependencyProperty MessageProperty = DependencyProperty.Register(nameof(Message), typeof(IMessage), typeof(MessageView), new PropertyMetadata(MessagesChangedCallback));
         public static readonly DependencyProperty MessageCountProperty = DependencyProperty.Register(nameof(MessageCount), typeof(int), typeof(MessageView), new PropertyMetadata(100, MessageCountChangedCallback));
         private SolidColorBrush[] _errorColors = new SolidColorBrush[] { new SolidColorBrush(Colors.Black), new SolidColorBrush(Colors.Green), new SolidColorBrush(Colors.Goldenrod), new SolidColorBrush(Colors.Orange), new SolidColorBrush(Colors.LightCoral), new SolidColorBrush(Colors.DarkRed) };
-        public Base.Interfaces.IMessage Message
+        public IMessage Message
         {
-            get { return (Base.Interfaces.IMessage)GetValue(MessageProperty); }
+            get { return (IMessage)GetValue(MessageProperty); }
             set { SetValue(MessageProperty, value); }
         }
         public int MessageCount
@@ -39,30 +40,30 @@ namespace View.UserControls
         private static void MessagesChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             MessageView owner = (MessageView)d;
-            Base.Interfaces.IMessage mess = e.NewValue as Base.Interfaces.IMessage;
+            IMessage mess = e.NewValue as IMessage;
             Run r = new Run();
-            if (mess is Base.Interfaces.IErrorMessage)
+            if (mess is IErrorMessage)
             {
-                Base.Interfaces.IErrorMessage err = mess as Base.Interfaces.IErrorMessage;
+                IErrorMessage err = mess as IErrorMessage;
                 r.Text = err.ToString();
                 owner.tb.Inlines.Add(r);
-                if (err.ErrorLevel.HasFlag(Base.Enumerations.ErrorLevel.Severe))
+                if (err.ErrorLevel.HasFlag(ErrorLevel.Severe))
                 {
                     owner.tb.Inlines.Last().Foreground = owner._errorColors[5];
                 }
-                else if (err.ErrorLevel.HasFlag(Base.Enumerations.ErrorLevel.Fatal))
+                else if (err.ErrorLevel.HasFlag(ErrorLevel.Fatal))
                 {
                     owner.tb.Inlines.Last().Foreground = owner._errorColors[4];
                 }
-                else if (err.ErrorLevel.HasFlag(Base.Enumerations.ErrorLevel.Major))
+                else if (err.ErrorLevel.HasFlag(ErrorLevel.Major))
                 {
                     owner.tb.Inlines.Last().Foreground = owner._errorColors[3];
                 }
-                else if (err.ErrorLevel.HasFlag(Base.Enumerations.ErrorLevel.Minor))
+                else if (err.ErrorLevel.HasFlag(ErrorLevel.Minor))
                 {
                     owner.tb.Inlines.Last().Foreground = owner._errorColors[2];
                 }
-                else if (err.ErrorLevel.HasFlag(Base.Enumerations.ErrorLevel.Info))
+                else if (err.ErrorLevel.HasFlag(ErrorLevel.Info))
                 {
                     owner.tb.Inlines.Last().Foreground = owner._errorColors[1];
                 }

--- a/View/UserControls/SelectableMessageView.xaml
+++ b/View/UserControls/SelectableMessageView.xaml
@@ -1,9 +1,9 @@
-﻿<UserControl x:Class="View.UserControls.SelectableMessageView"
+﻿<UserControl x:Class="HEC.MVVMFramework.View.UserControls.SelectableMessageView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:View.UserControls"
+             xmlns:local="clr-namespace:HEC.MVVMFramework.View.UserControls"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="400">
     <Grid >

--- a/View/UserControls/SelectableMessageView.xaml.cs
+++ b/View/UserControls/SelectableMessageView.xaml.cs
@@ -1,7 +1,8 @@
-﻿using System.Windows;
+﻿using HEC.MVVMFramework.Base.Implementations;
+using System.Windows;
 using System.Windows.Controls;
 
-namespace View.UserControls
+namespace HEC.MVVMFramework.View.UserControls
 {
     /// <summary>
     /// Interaction logic for SelectableMessageView.xaml
@@ -14,7 +15,7 @@ namespace View.UserControls
             InitializeComponent();
             //System.Diagnostics.Debugger.Break();
             DataContext = _vm;
-            Base.Implementations.MessageHub.Subscribe(_vm);
+            MessageHub.Subscribe(_vm);
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)

--- a/View/UserControls/SubscriberMessageView.xaml
+++ b/View/UserControls/SubscriberMessageView.xaml
@@ -1,9 +1,9 @@
-﻿<UserControl x:Class="View.UserControls.SubscriberMessageView"
+﻿<UserControl x:Class="HEC.MVVMFramework.View.UserControls.SubscriberMessageView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:View.UserControls"
+             xmlns:local="clr-namespace:HEC.MVVMFramework.View.UserControls"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <Grid>

--- a/View/UserControls/SubscriberMessageView.xaml.cs
+++ b/View/UserControls/SubscriberMessageView.xaml.cs
@@ -1,29 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using Base.Enumerations;
-using Base.Events;
+using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Implementations;
 
-namespace View.UserControls
+namespace HEC.MVVMFramework.View.UserControls
 {
     /// <summary>
     /// Interaction logic for SubscriberMessageView.xaml
     /// </summary>
     public partial class SubscriberMessageView : UserControl
     {
-        public static readonly DependencyProperty FilterLevelProperty = DependencyProperty.Register(nameof(FilterLevel), typeof(Base.Enumerations.ErrorLevel), typeof(SubscriberMessageView), new PropertyMetadata(Base.Enumerations.ErrorLevel.Unassigned, FilterLevelChangedCallback));
+        public static readonly DependencyProperty FilterLevelProperty = DependencyProperty.Register(nameof(FilterLevel), typeof(ErrorLevel), typeof(SubscriberMessageView), new PropertyMetadata(ErrorLevel.Unassigned, FilterLevelChangedCallback));
         public static readonly DependencyProperty SenderTypeFilterProperty = DependencyProperty.Register(nameof(SenderTypeFilter), typeof(System.Type), typeof(SubscriberMessageView), new PropertyMetadata(null, SenderTypeFilterChangedCallback));
         public static readonly DependencyProperty MessageTypeFilterProperty = DependencyProperty.Register(nameof(MessageTypeFilter), typeof(System.Type), typeof(SubscriberMessageView), new PropertyMetadata(null, MessageTypeFilterChangedCallback));
         public static readonly DependencyProperty MessageCountProperty = DependencyProperty.Register(nameof(MessageCount), typeof(int), typeof(SubscriberMessageView), new PropertyMetadata(100, MessageCountChangedCallback));
@@ -38,7 +26,7 @@ namespace View.UserControls
         {
             get
             {
-                return (Base.Enumerations.ErrorLevel)GetValue(FilterLevelProperty);
+                return (ErrorLevel)GetValue(FilterLevelProperty);
             }
             set
             {
@@ -74,7 +62,7 @@ namespace View.UserControls
             _vm.FilterLevel = FilterLevel;
             _vm.SenderTypeFilter = SenderTypeFilter;
             _vm.MessageTypeFilter = MessageTypeFilter;
-            Base.Implementations.MessageHub.Subscribe(_vm);
+            MessageHub.Subscribe(_vm);
         }
         private static void FilterLevelChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/View/UserControls/TextBoxFileBrowserControl.xaml
+++ b/View/UserControls/TextBoxFileBrowserControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="View.UserControls.TextBoxFileBrowserControl"
+﻿<UserControl x:Class="HEC.MVVMFramework.View.UserControls.TextBoxFileBrowserControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 

--- a/View/UserControls/TextBoxFileBrowserControl.xaml.cs
+++ b/View/UserControls/TextBoxFileBrowserControl.xaml.cs
@@ -2,7 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 
-namespace View.UserControls
+namespace HEC.MVVMFramework.View.UserControls
 {
     public partial class TextBoxFileBrowserControl : UserControl
     {

--- a/View/UserControls/TextBoxFolderBrowserControl.xaml
+++ b/View/UserControls/TextBoxFolderBrowserControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="View.UserControls.TextBoxFolderBrowserControl"
+﻿<UserControl x:Class="HEC.MVVMFramework.View.UserControls.TextBoxFolderBrowserControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 

--- a/View/UserControls/TextBoxFolderBrowserControl.xaml.cs
+++ b/View/UserControls/TextBoxFolderBrowserControl.xaml.cs
@@ -4,7 +4,7 @@ using System.Windows.Controls;
 using Microsoft.WindowsAPICodePack.Dialogs;
 using System.IO;
 
-namespace View.UserControls
+namespace HEC.MVVMFramework.View.UserControls
 {
     public partial class TextBoxFolderBrowserControl : UserControl
     {

--- a/View/View.csproj
+++ b/View/View.csproj
@@ -9,12 +9,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<PackageId>HenryGeorgist.Framework.View</PackageId>
+		<PackageId>HEC.MVVMFramework.View</PackageId>
 		<VersionPrefix>1.0.0</VersionPrefix>
 		<Description>A library providing functionality for MVVM Views</Description>
 		<Authors>Will Lehman</Authors>
 		<RepositoryUrl>https://github.com/HenryGeorgist/Framework</RepositoryUrl>
 		<DebugType>embedded</DebugType>
+		<RootNamespace>HEC.MVVMFramework.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/View/Windows/BasicWindow.xaml
+++ b/View/Windows/BasicWindow.xaml
@@ -1,10 +1,10 @@
-﻿<local:Window x:Class="View.Windows.BasicWindow"
+﻿<local:Window x:Class="HEC.MVVMFramework.View.Windows.BasicWindow"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:View.Windows"
-             xmlns:v="clr-namespace:View.NamedActionConverters"
+             xmlns:local="clr-namespace:HEC.MVVMFramework.View.Windows"
+             xmlns:v="clr-namespace:HEC.MVVMFramework.View.NamedActionConverters"
              mc:Ignorable="d">
     <local:Window.Resources>
         <ResourceDictionary Source="/View;component/ResourceDictionary.xaml"/>

--- a/View/Windows/BasicWindow.xaml.cs
+++ b/View/Windows/BasicWindow.xaml.cs
@@ -1,5 +1,5 @@
 ﻿using System.Windows;
-namespace View.Windows
+namespace HEC.MVVMFramework.View.Windows
 {
     /// <summary>
     /// Interaction logic for BasicWindow.xaml

--- a/View/Windows/Window.cs
+++ b/View/Windows/Window.cs
@@ -1,6 +1,8 @@
-﻿using ViewModel.Events;
+﻿using HEC.MVVMFramework.Base.Implementations;
+using HEC.MVVMFramework.Base.Interfaces;
+using ViewModel.Events;
 
-namespace View.Windows
+namespace HEC.MVVMFramework.View.Windows
 {
     public class Window: System.Windows.Window
     {
@@ -26,13 +28,13 @@ namespace View.Windows
             {
                 ((ViewModel.Interfaces.IUpdatePlot)bvm).UpdatePlotEvent += Vm_UpdatePlot;
             }
-            if(bvm is Base.Interfaces.IReportMessage)
+            if(bvm is IReportMessage)
             {
-                Base.Implementations.MessageHub.Register(bvm as Base.Interfaces.IReportMessage);
+                MessageHub.Register(bvm as IReportMessage);
             }
-            if (bvm is Base.Interfaces.IRecieveMessages)
+            if (bvm is IRecieveMessages)
             {
-                Base.Implementations.MessageHub.Subscribe(bvm as Base.Interfaces.IRecieveMessages);
+                MessageHub.Subscribe(bvm as IRecieveMessages);
             }
             if (bvm is ViewModel.Interfaces.IClose)
             {

--- a/ViewModel/Implementations/ErrorReportViewModel.cs
+++ b/ViewModel/Implementations/ErrorReportViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -9,10 +11,10 @@ namespace ViewModel.Implementations
 {
     public class ErrorReportViewModel : Implementations.BaseViewModel
     {
-        private Base.Interfaces.IMessage _message;
+        private IMessage _message;
         private int _messageCount = 100;
         private System.Diagnostics.Stopwatch s = new System.Diagnostics.Stopwatch();
-        public Base.Interfaces.IMessage IMessage
+        public IMessage IMessage
         {
             get { return _message; }
             set { _message = value; NotifyPropertyChanged(); }
@@ -28,16 +30,16 @@ namespace ViewModel.Implementations
                 _messageCount = value; NotifyPropertyChanged();
             }
         }
-        public void SetErrors(Dictionary<string, Base.Interfaces.IPropertyRule> ruleMap)
+        public void SetErrors(Dictionary<string, IPropertyRule> ruleMap)
         {
-            Base.Interfaces.IMessage imsg = null;
+            IMessage imsg = null;
             int messageCount = ruleMap.Values.Count();
             MessageCounter = messageCount;
 
-            foreach (Base.Interfaces.IPropertyRule r in ruleMap.Values)
+            foreach (IPropertyRule r in ruleMap.Values)
             {
                 string msg = "";
-                if (r.ErrorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                if (r.ErrorLevel > ErrorLevel.Unassigned)
                 {
 
                     foreach (string m in r.Errors)

--- a/ViewModel/Implementations/HierarchicalViewModel.cs
+++ b/ViewModel/Implementations/HierarchicalViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using HEC.MVVMFramework.Base.Implementations;
+using HEC.MVVMFramework.Base.Interfaces;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using ViewModel.Events;
 using ViewModel.Interfaces;
@@ -112,10 +114,10 @@ namespace ViewModel.Implementations
                 INavigate ele = child as INavigate;
                 ele.NavigationEvent += Navigate;
             }
-            if(child is Base.Interfaces.IReportMessage)
+            if(child is IReportMessage)
             {
-                Base.Interfaces.IReportMessage ele = child as Base.Interfaces.IReportMessage;
-                Base.Implementations.MessageHub.Register(ele);
+                IReportMessage ele = child as IReportMessage;
+                MessageHub.Register(ele);
             }
             //if (child.GetType().GetInterfaces().Contains(typeof(ICanClose)))
             //{

--- a/ViewModel/Implementations/SelectableMessageViewModel.cs
+++ b/ViewModel/Implementations/SelectableMessageViewModel.cs
@@ -4,17 +4,20 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Base.Enumerations;
-using Base.Events;
 using System.Reflection;
+using HEC.MVVMFramework.Base.Attributes;
+using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Events;
+using HEC.MVVMFramework.Base.Interfaces;
+using HEC.MVVMFramework.Base.Implementations;
 
 namespace ViewModel.Implementations
 {
-    public class SelectableMessageViewModel : Base.Interfaces.IRecieveMessages, System.ComponentModel.INotifyPropertyChanged
+    public class SelectableMessageViewModel : IRecieveMessages, System.ComponentModel.INotifyPropertyChanged
     {
-        private Base.Interfaces.IMessage _message;
+        private IMessage _message;
         public event PropertyChangedEventHandler PropertyChanged;
-        private Base.Enumerations.ErrorLevel _filterLevel = ErrorLevel.Unassigned;
+        private ErrorLevel _filterLevel = ErrorLevel.Unassigned;
         private Type _messageType = null;
         private int _messageCount = 10;
         private Type _senderType = null;
@@ -24,7 +27,7 @@ namespace ViewModel.Implementations
         {
             get { return _reporters; }
         }
-        public Base.Interfaces.IMessage IMessage
+        public IMessage IMessage
         {
             get { return _message; }
             set { _message = value; NotifyPropertyChanged(); }
@@ -95,8 +98,8 @@ namespace ViewModel.Implementations
         }
         public SelectableMessageViewModel()
         {
-            Base.Implementations.MessageHub.ReporterAdded += MessageHub_ReporterAdded;
-            Base.Implementations.MessageHub.ReporterRemoved += MessageHub_ReporterRemoved;
+            MessageHub.ReporterAdded += MessageHub_ReporterAdded;
+            MessageHub.ReporterRemoved += MessageHub_ReporterRemoved;
             MessageHub_ReporterAdded(null, null);
 
         }
@@ -104,9 +107,9 @@ namespace ViewModel.Implementations
         {
             _reporters = new List<TypeRepresentation>();
             TypeRepresentation nullType = new TypeRepresentation();
-            nullType.Count = Base.Implementations.MessageHub.Reporters.Count();
+            nullType.Count = MessageHub.Reporters.Count();
             _reporters.Add(nullType);
-            foreach (Base.Interfaces.IReportMessage r in Base.Implementations.MessageHub.Reporters)
+            foreach (IReportMessage r in MessageHub.Reporters)
             {
                 TypeRepresentation newTr = new TypeRepresentation(r);
                 bool hasMatch = false;
@@ -151,7 +154,7 @@ namespace ViewModel.Implementations
                 Count = 1;
                 Type t = o.GetType();
                 System.Reflection.TypeInfo ti = t.GetTypeInfo();
-                Base.Attributes.ReporterDisplayNameAttribute rdma = (Base.Attributes.ReporterDisplayNameAttribute)ti.GetCustomAttribute(typeof(Base.Attributes.ReporterDisplayNameAttribute));
+                ReporterDisplayNameAttribute rdma = (ReporterDisplayNameAttribute)ti.GetCustomAttribute(typeof(ReporterDisplayNameAttribute));
                 if (rdma != null)
                 {
                     Name = rdma.DisplayName;

--- a/ViewModel/Implementations/SubscriberMessageViewModel.cs
+++ b/ViewModel/Implementations/SubscriberMessageViewModel.cs
@@ -4,20 +4,21 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Base.Enumerations;
-using Base.Events;
+using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Events;
+using HEC.MVVMFramework.Base.Interfaces;
 
 namespace ViewModel.Implementations
 {
-    public class SubscriberMessageViewModel : Base.Interfaces.IRecieveMessages, System.ComponentModel.INotifyPropertyChanged
+    public class SubscriberMessageViewModel : IRecieveMessages, System.ComponentModel.INotifyPropertyChanged
     {
-        private Base.Interfaces.IMessage _message;
+        private IMessage _message;
         public event PropertyChangedEventHandler PropertyChanged;
-        private Base.Enumerations.ErrorLevel _filterLevel = ErrorLevel.Unassigned;
+        private ErrorLevel _filterLevel = ErrorLevel.Unassigned;
         private Type _senderType = null;
         private Type _messageType = null;
         private int _messageCount = 100;
-        public Base.Interfaces.IMessage IMessage
+        public IMessage IMessage
         {
             get { return _message; }
             set { _message = value; NotifyPropertyChanged(); }

--- a/ViewModel/Implementations/ValidatingBaseViewModel.cs
+++ b/ViewModel/Implementations/ValidatingBaseViewModel.cs
@@ -2,7 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Base.Interfaces;
+using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
 using ViewModel.Events;
 
 namespace ViewModel.Implementations
@@ -14,15 +15,15 @@ namespace ViewModel.Implementations
         private Dictionary<string, IPropertyRule> _RuleMap = new Dictionary<string, IPropertyRule>();
         private List<string> _Errors;
         private NamedAction _ErrorsAction;
-        private Base.Enumerations.ErrorLevel _errorLevel;
+        private ErrorLevel _errorLevel;
         public bool HasErrors
         {
             get
             {
-                return _errorLevel > Base.Enumerations.ErrorLevel.Unassigned;
+                return _errorLevel > ErrorLevel.Unassigned;
             }
         }
-        public Base.Interfaces.INamedAction ErrorsAction
+        public INamedAction ErrorsAction
         {
             get { return _ErrorsAction; }
             set { _ErrorsAction = (NamedAction)value; }
@@ -34,7 +35,7 @@ namespace ViewModel.Implementations
                 return _RuleMap;
             }
         }
-        public Base.Enumerations.ErrorLevel ErrorLevel
+        public ErrorLevel ErrorLevel
         {
             get { return _errorLevel; }
         }
@@ -88,7 +89,7 @@ namespace ViewModel.Implementations
             if (propertyName == null) return null;
             if (_RuleMap.ContainsKey(propertyName))
             {
-                if (_RuleMap[propertyName].ErrorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                if (_RuleMap[propertyName].ErrorLevel > ErrorLevel.Unassigned)
                 {
                     return _RuleMap[propertyName].Errors;
                 }
@@ -110,14 +111,14 @@ namespace ViewModel.Implementations
         public void Validate()
         {
             _Errors = new List<string>();
-            Base.Enumerations.ErrorLevel prevErrorState = _errorLevel;
-            _errorLevel = Base.Enumerations.ErrorLevel.Unassigned;
+            ErrorLevel prevErrorState = _errorLevel;
+            _errorLevel = ErrorLevel.Unassigned;
             foreach (string s in _RuleMap.Keys)
             {
                 _RuleMap[s].Update();
-                if (_RuleMap[s].ErrorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                if (_RuleMap[s].ErrorLevel > ErrorLevel.Unassigned)
                 {
-                    if (_errorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                    if (_errorLevel > ErrorLevel.Unassigned)
                     {
                         _errorLevel = _RuleMap[s].ErrorLevel;
                     }
@@ -128,15 +129,15 @@ namespace ViewModel.Implementations
                     _Errors.AddRange(_RuleMap[s].Errors);
                 }
             }
-            if (_errorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+            if (_errorLevel > ErrorLevel.Unassigned)
             {
                 //errors exist
                 if (_errorLevel != prevErrorState)
                 {
-                    Base.Enumerations.ErrorLevel changed = _errorLevel ^ prevErrorState;
+                    ErrorLevel changed = _errorLevel ^ prevErrorState;
                     NotifyPropertyChanged(nameof(HasErrors));
                     if (ErrorsAction is ViewModel.Interfaces.IDisplayToUI) { ((ViewModel.Interfaces.IDisplayToUI)ErrorsAction).IsEnabled = HasErrors; }
-                    foreach (Base.Enumerations.ErrorLevel e in Enum.GetValues(typeof(Base.Enumerations.ErrorLevel)))
+                    foreach (ErrorLevel e in Enum.GetValues(typeof(ErrorLevel)))
                     {
                         if ((changed & e) > 0)
                         {
@@ -164,14 +165,14 @@ namespace ViewModel.Implementations
         }
         public void Validate(string propertyName)
         {
-            Base.Enumerations.ErrorLevel prevState = _RuleMap[propertyName].ErrorLevel;
+            ErrorLevel prevState = _RuleMap[propertyName].ErrorLevel;
             _RuleMap[propertyName].Update();
             if (prevState != _RuleMap[propertyName].ErrorLevel)
             {
                 //a change occured.
 
                 ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
-                Base.Enumerations.ErrorLevel currState = _RuleMap[propertyName].ErrorLevel;
+                ErrorLevel currState = _RuleMap[propertyName].ErrorLevel;
 
                 //check if it is the biggest one.
                 bool biggerErrorsExist = false;
@@ -184,8 +185,8 @@ namespace ViewModel.Implementations
                 }
                 if (!biggerErrorsExist)
                 {
-                    if (currState == Base.Enumerations.ErrorLevel.Unassigned) _errorLevel = currState;
-                    if (_errorLevel > Base.Enumerations.ErrorLevel.Unassigned)
+                    if (currState == ErrorLevel.Unassigned) _errorLevel = currState;
+                    if (_errorLevel > ErrorLevel.Unassigned)
                     {
                         _errorLevel = _errorLevel | currState;
                     }

--- a/ViewModel/Interfaces/IDisplayToUI.cs
+++ b/ViewModel/Interfaces/IDisplayToUI.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HEC.MVVMFramework.Base.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ViewModel.Interfaces
 {
-    public interface IDisplayToUI: Base.Interfaces.INamed
+    public interface IDisplayToUI: INamed
     {
         bool IsEnabled { get; set; }
         bool IsVisible { get; set; }

--- a/ViewModel/Interfaces/IDisplayableNamedAction.cs
+++ b/ViewModel/Interfaces/IDisplayableNamedAction.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HEC.MVVMFramework.Base.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ViewModel.Interfaces
 {
-    public interface IDisplayableNamedAction: IDisplayToUI, Base.Interfaces.INamedAction
+    public interface IDisplayableNamedAction: IDisplayToUI, INamedAction
     {
     }
 }

--- a/ViewModel/Validation/PropertyRule.cs
+++ b/ViewModel/Validation/PropertyRule.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using Base.Interfaces;
+using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
 
 namespace ViewModel.Validation
 {
-    public class PropertyRule : Base.Interfaces.IPropertyRule
+    public class PropertyRule : IPropertyRule
     {
         private List<IRule> _rules = new List<IRule>();
         private List<string> _errors;
-        private Base.Enumerations.ErrorLevel _errorLevel;
+        private ErrorLevel _errorLevel;
         public IEnumerable<string> Errors
         {
             get
@@ -24,7 +25,7 @@ namespace ViewModel.Validation
                 return _rules;
             }
         }
-        public Base.Enumerations.ErrorLevel ErrorLevel
+        public ErrorLevel ErrorLevel
         {
             get
             {
@@ -49,7 +50,7 @@ namespace ViewModel.Validation
         public void Update()
         {
             _errors = new List<string>();
-            _errorLevel = Base.Enumerations.ErrorLevel.Unassigned;
+            _errorLevel = ErrorLevel.Unassigned;
             try
             {
                 foreach (IRule r in _rules)
@@ -57,7 +58,7 @@ namespace ViewModel.Validation
                     if (!r.Expression())
                     {
                         _errors.Add(r.Message);
-                        if(_errorLevel > Base.Enumerations.ErrorLevel.Unassigned) {
+                        if(_errorLevel > ErrorLevel.Unassigned) {
                              _errorLevel = _errorLevel | r.ErrorLevel;
                         }else
                         {
@@ -70,7 +71,7 @@ namespace ViewModel.Validation
             catch (Exception e)
             {
                 _errors.Add(e.Message);
-                _errorLevel = Base.Enumerations.ErrorLevel.Fatal;
+                _errorLevel = ErrorLevel.Fatal;
                 //NotifyPropertyChanged(nameof(Error));
                 //if(HasError != prevState) { NotifyPropertyChanged(nameof(HasError)); }
             }

--- a/ViewModel/Validation/Rule.cs
+++ b/ViewModel/Validation/Rule.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using HEC.MVVMFramework.Base.Enumerations;
+using HEC.MVVMFramework.Base.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,11 +8,11 @@ using System.Threading.Tasks;
 
 namespace ViewModel.Validation
 {
-    public class Rule : Base.Interfaces.IRule
+    public class Rule : IRule
     {
         private readonly Func<bool> _expression;
         private readonly string _message;
-        private readonly Base.Enumerations.ErrorLevel _errorLevel;
+        private readonly ErrorLevel _errorLevel;
         public Func<bool> Expression
         {
             get
@@ -25,14 +27,14 @@ namespace ViewModel.Validation
                 return _message;
             }
         }
-        public Base.Enumerations.ErrorLevel ErrorLevel
+        public ErrorLevel ErrorLevel
         {
             get { return _errorLevel; }
         }
-        public Rule(Func<bool> expr, string msg):this(expr,msg,Base.Enumerations.ErrorLevel.Info)
+        public Rule(Func<bool> expr, string msg):this(expr,msg, ErrorLevel.Info)
         {
         }
-        public Rule(Func<bool> expr, string msg, Base.Enumerations.ErrorLevel errorLevel)
+        public Rule(Func<bool> expr, string msg, ErrorLevel errorLevel)
         {
             _expression = expr;
             _message = msg;

--- a/ViewModel/ViewModel.csproj
+++ b/ViewModel/ViewModel.csproj
@@ -7,12 +7,13 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<PackageId>HenryGeorgist.Framework.ViewModel</PackageId>
+		<PackageId>HEC.MVVMFramework.ViewModel</PackageId>
 		<VersionPrefix>1.0.0</VersionPrefix>
 		<Description>A library providing functionality for MVVM ViewModels</Description>
 		<Authors>Will Lehman</Authors>
 		<RepositoryUrl>https://github.com/HenryGeorgist/Framework</RepositoryUrl>
 		<DebugType>embedded</DebugType>
+		<RootNamespace>HEC.MVVMFramework.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Changed namespace to a format that's more easily explicitly referenced by other projects. We were getting really difficult namespace/type conflicts just referencing ViewModel. This change basically adds a prefix of HEC.MVVMFramework to all the projects in the solution. 
